### PR TITLE
enable shared content

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,28 @@ platforms:
   armhf:
     build-on: [armhf]
 
+## on consumer side, add plug and layout like
+#  plugs:
+#    git-cli:
+#      interface: content
+#      target: $SNAP/git-snap
+#      default-provider: git-confined
+# layout:
+#   /usr/local/bin:
+#     bind: $SNAP/git-snap/bin
+#   /usr/libexec/git-core:
+#     symlink: $SNAP/git-snap/git-core
+#   /usr/share/git-core/templates:
+#     symlink: $SNAP/git-snap/templates
+slots:
+  git-cli:
+    interface: content
+    source:
+      read:
+        - $SNAP/usr/bin
+        - $SNAP/usr/libexec/git-core
+        - $SNAP/usr/share/git-core/templates
+
 apps:
   git-confined:
     environment:


### PR DESCRIPTION
Primary thought:
Not sure if confinement and sharing content can be friends - i have a showcase over there.
https://github.com/janesser/eclipse-snap/blob/master/snapcraft.yaml.template

I caught a glibc complication having mixed core24 and core22 - i shall retry and analyse more carefully.

Secondary thoughts:
i use ssh-agent socket which may be injected instead/in-addition of .ssh folder.

